### PR TITLE
Remove vinyls-related content from site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,7 +105,7 @@ analytics:
 author:
   name             : # "அபிஷேக் பாபு"
   avatar           : "/assets/images/me.jpg"
-  bio              : "Software Engineer & Vinyl Collector"
+  bio              : "Software Engineer"
   location         : "Redwood City, CA"
   email            : # "abbabu0411@gmail.com"
   links:
@@ -121,9 +121,7 @@ author:
     - label: "Twitter"
       icon: "fab fa-twitter"
       url: "https://twitter.com/abhishekbabu04"
-    - label: "Vinyls"
-      icon: "fab fa-instagram"
-      url: "https://www.instagram.com/abhi_for_the_record/"
+
     - label: "Email"
       icon: "fas fa-fw fa-envelope"
       url: "mailto:abbabu0411@gmail.com"
@@ -143,9 +141,7 @@ footer:
     - label: "Twitter"
       icon: "fab fa-twitter"
       url: "https://twitter.com/abhishekbabu04"
-    - label: "Vinyls"
-      icon: "fab fa-instagram"
-      url: "https://www.instagram.com/abhi_for_the_record/"
+
     - label: "Email"
       icon: "fas fa-fw fa-envelope"
       url: "mailto:abbabu0411@gmail.com"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,5 +8,3 @@ main:
     url: "/projects"
   - title: "Academics"
     url: "/academics"
-  - title: "Vinyls"
-    url: "/vinyls"

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -4,7 +4,7 @@ title: "Hello!"
 layout: single
 ---
 
-I'm a Software Engineer at [Robinhood](https://robinhood.com/us/en/){:target="_blank"} and an alumnus of the [Paul G. Allen School of Computer Science & Engineering](https://cs.washington.edu){:target="_blank"} at the [University of Washington](https://washington.edu){:target="_blank"}. I'm also an avid music listener and vinyl collector.
+I'm a Software Engineer at [Robinhood](https://robinhood.com/us/en/){:target="_blank"} and an alumnus of the [Paul G. Allen School of Computer Science & Engineering](https://cs.washington.edu){:target="_blank"} at the [University of Washington](https://washington.edu){:target="_blank"}.
 
 My primary interests lie in:
  * <span style="color:#32cd77"><i class="fas fa-money-check-alt"></i></span> Payments & Money Movement

--- a/_pages/vinyls.md
+++ b/_pages/vinyls.md
@@ -1,9 +1,0 @@
----
-permalink: /vinyls
-title: "Vinyls"
-layout: single
----
-
-## Coming soon!
-
-Meanwhile, check out my [Instagram page](https://www.instagram.com/abhi_for_the_record/){:target="_blank"} dedicated to my vinyl collection!


### PR DESCRIPTION
This PR removes all vinyl-related content from the personal website:

## Changes
- Deleted the Vinyls page (_pages/vinyls.md)
- Removed Vinyls link from main navigation (_data/navigation.yml)
- Updated author bio from 'Software Engineer & Vinyl Collector' to 'Software Engineer' (_config.yml)
- Removed Instagram vinyls link from sidebar (_config.yml)
- Removed Instagram vinyls link from footer (_config.yml)
- Updated home page bio to remove vinyl collector reference (_pages/home.md)